### PR TITLE
Support for building via terminal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ FrogLord.jar
 /nbproject/
 /build/
 /dist/
+target/
 build.xml
 /.idea/workspace.xml

--- a/README.md
+++ b/README.md
@@ -18,13 +18,33 @@ If you need any help, have questions, or want to get in touch, don't hesitate to
 Yes! Pull requests are welcome.  
 
 ## Build Instructions:
-Using the IntelliJ IDE, setting up FrogLord is very simple.  
+
+### Using IntelliJ
+
+**Setup:**
 1. Select ``Git`` from the ``Check out from Version Control`` option on the main menu. (It may be ``File > New > Project from Version Control`` if you're not on the main menu.)  
 2. Clone this repository. The URL is: ``https://github.com/Kneesnap/FrogLord.git``.
 3. Install the Lombok IntelliJ Plugin using the steps found [here](https://projectlombok.org/setup/intellij).
 
-Run FrogLord: ``Run > Run 'FrogLord GUI'``  
-Create FrogLord.jar: ``Build > Build Artifacts... > FrogLord > Build``
+**Running:**
+1. ``Run > Run 'FrogLord GUI'``  
+
+**Building:**
+1. ``Build > Build Artifacts... > FrogLord > Build``
+
+### Using Maven
+
+**Setup:**
+1. ``git clone https://github.com/Kneesnap/FrogLord.git``
+2. ``cd FrogLord``
+3. ``mvn compile`` - Verify code compiles
+
+**Building:**
+1. ``mvn package``
+
+**Running:**
+1. ``java -jar target/editor-{version}-jar-with-dependencies.jar`` 
+    * `{version}` is the current release
 
 ## Special Thanks:
  - Andy Eder (Frogger 2 Programmer, Significant FrogLord contributor)

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,62 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>net.highwayfrogs</groupId>
+	<artifactId>editor</artifactId>
+	<url>https://github.com/Kneesnap/FrogLord</url>
+	<version>0.5.0</version>
+	<name>FrogLord</name>
+	<description>An editor for Frogger: He's Back (1997)</description>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>1.18.10</version>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+	<build>
+		<!-- Project is not in standard maven structure, must specify src/resources folders -->
+		<sourceDirectory>src</sourceDirectory>
+		<resources>
+			<resource>
+				<directory>resources</directory>
+			</resource>
+		</resources>
+		<plugins>
+			<!-- Target Java 8 -->
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.0</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
+			<!-- Bundle classes/resources to runnable jar -->
+			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<archive>
+						<manifest>
+							<mainClass>net.highwayfrogs.editor.gui.GUIMain</mainClass>
+						</manifest>
+					</archive>
+					<descriptorRefs>
+						<descriptorRef>jar-with-dependencies</descriptorRef>
+					</descriptorRefs>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>


### PR DESCRIPTION
On discord we had a discussion about maven. We agreed that there isn't a need to mavenize the project. Adding this `pom.xml` doesn't change any existing IntelliJ behavior. It simply opens the door for others to import the project as a maven project if they're using another IDE.

Also, it allows building of a jar with a simple `mvn package` without the need to open an IDE, which may be useful for those who want the latest build without having to wait on a release.