### PR TITLE
The Dreaded .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ FrogLord.jar
 target/
 build.xml
 /.idea/workspace.xml
+.DS_Store


### PR DESCRIPTION
If you've ever coded on Mac OSX before, you'll know what I'm talking about. This mentally retarded little file annoys the hell out of me. It should always be added to the .gitignore when creating a new repo.