### PR TITLE
Added buttons to speed up position editing

### DIFF
--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/path/segments/FroggerPathSegmentLine.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/path/segments/FroggerPathSegmentLine.java
@@ -58,9 +58,10 @@ public class FroggerPathSegmentLine extends FroggerPathSegment {
         int deltaZ = this.end.getZ() - this.start.getZ();
 
         SVector result = new SVector();
-        result.setX((short) (this.start.getX() + ((deltaX * info.getSegmentDistance()) / getLength())));
-        result.setY((short) (this.start.getY() + ((deltaY * info.getSegmentDistance()) / getLength())));
-        result.setZ((short) (this.start.getZ() + ((deltaZ * info.getSegmentDistance()) / getLength())));
+        int length = getLength();
+        result.setX((short) (this.start.getX() + (length != 0 ? ((deltaX * info.getSegmentDistance()) / length) : 0)));
+        result.setY((short) (this.start.getY() + (length != 0 ? ((deltaY * info.getSegmentDistance()) / length) : 0)));
+        result.setZ((short) (this.start.getZ() + (length != 0 ? ((deltaZ * info.getSegmentDistance()) / length) : 0)));
         return new FroggerPathResult(result, new IVector(deltaX, deltaY, deltaZ).normalise());
     }
 

--- a/src/net/highwayfrogs/editor/gui/GUIEditorGrid.java
+++ b/src/net/highwayfrogs/editor/gui/GUIEditorGrid.java
@@ -850,7 +850,52 @@ public class GUIEditorGrid {
         vecPane.setHgap(10);
         GridPane.setColumnSpan(vecPane, 2); // Make it take up the full space in the grid it will be added to.
         setupNode(vecPane); // Setup this in the new area.
-        addRow(75);
+        addRow(85);
+
+        GridPane vecPaneExtraButtons = new GridPane();
+        vecPaneExtraButtons.addRow(0);
+
+        // Copy the position so it can be pasted later
+        Button btn = new Button("Copy");
+        btn.setOnMouseClicked(evt -> {
+            if (controller != null) {
+                controller.setCopiedPosition(new SVector(vector.getFloatX(bits), vector.getFloatY(bits), vector.getFloatZ(bits)));
+                onPass.run();
+            }
+        });
+
+        vecPaneExtraButtons.addColumn(0, btn);
+
+        // Paste the position that has been previously copied
+        btn = new Button("Paste");
+        btn.setOnMouseClicked(evt -> {
+            if (controller != null && controller.getCopiedPosition() != null) {
+                SVector copy = controller.getCopiedPosition();
+                vector.setFloatX(copy.getFloatX(), bits);
+                vector.setFloatY(copy.getFloatY(), bits);
+                vector.setFloatZ(copy.getFloatZ(), bits);
+                xField.setText(String.valueOf(vector.getFloatX(bits)));
+                yField.setText(String.valueOf(vector.getFloatY(bits)));
+                zField.setText(String.valueOf(vector.getFloatZ(bits)));
+                onPass.run();
+            }
+        });
+
+        vecPaneExtraButtons.addColumn(1, btn);
+
+        // Relocate the position to whatever polygon is selected
+        btn = new Button("Select");
+        btn.setDisable(true);
+        btn.setOnMouseClicked(evt -> {
+            // TODO: When polygon selection is re-added, add the functionality here as well
+        });
+
+        vecPaneExtraButtons.addColumn(2, btn);
+
+        vecPaneExtraButtons.setHgap(10);
+        GridPane.setColumnSpan(vecPaneExtraButtons, 2); // Make it take up the full space in the grid it will be added to.
+        setupNode(vecPaneExtraButtons); // Setup this in the new area.
+        addRow(35);
     }
 
     /**
@@ -2071,7 +2116,8 @@ public class GUIEditorGrid {
             onChange();
         }));
 
-        slider.setMajorTickUnit((maxValue - minValue) / 4);
+        if (maxValue - minValue > 0)
+            slider.setMajorTickUnit((maxValue - minValue) / 4);
         slider.setShowTickLabels(true);
         slider.setShowTickMarks(true);
         slider.setMinorTickCount(0);

--- a/src/net/highwayfrogs/editor/gui/editor/MeshViewController.java
+++ b/src/net/highwayfrogs/editor/gui/editor/MeshViewController.java
@@ -21,6 +21,8 @@ import javafx.scene.shape.MeshView;
 import javafx.stage.Stage;
 import javafx.util.converter.NumberStringConverter;
 import lombok.Getter;
+import lombok.Setter;
+import net.highwayfrogs.editor.file.standard.SVector;
 import net.highwayfrogs.editor.games.generic.GameInstance;
 import net.highwayfrogs.editor.games.psx.shading.IPSXShadedMesh;
 import net.highwayfrogs.editor.gui.GUIMain;
@@ -59,6 +61,9 @@ public abstract class MeshViewController<TMesh extends DynamicMesh> implements I
     private final GameInstance gameInstance;
     private SubScene subScene;
     private final Map<MeshView, ChangeListener<DrawMode>> meshViewDrawModeListeners = new HashMap<>();
+
+    // Position copied by the user
+    @Setter private SVector copiedPosition;
 
     // Baseline UI components
     @FXML private AnchorPane anchorPaneUIRoot;
@@ -139,6 +144,7 @@ public abstract class MeshViewController<TMesh extends DynamicMesh> implements I
         this.gameInstance = instance;
         this.inputManager = new InputManager(instance);
         this.firstPersonCamera = new FirstPersonCamera(this.inputManager);
+        this.copiedPosition = null;
     }
 
     @Override


### PR DESCRIPTION
Merging in some of the changes I made to the 0.5.0 tag to move positions around easier.
It looks like the polygon selection functionality for entities is commented out, which is what I used for the Select button. I left the button in but disabled, for future consideration.

### Buttons Added
**Copy** - Copies the selected position
**Paste** - Pastes a previously copied position to the selected position
**Select** - Disabled. Will update a position by selecting a polygon, in the same way a new entity added to the map is done.

**Misc Changes**
With this new functionality it is easy to overlay a path line start and end in the exact same position. Added some simple error prevention.
