### PR TITLE
vuln-fix: Partial Path Traversal Vulnerability in Cloned Code

### DIFF
--- a/src/net/highwayfrogs/editor/utils/FileUtils.java
+++ b/src/net/highwayfrogs/editor/utils/FileUtils.java
@@ -432,7 +432,7 @@ public class FileUtils {
 
         // Search parent files.
         while (testFile != null) {
-            if (testFile.equals(holdingFolder))
+            if (testFile.getCanonicalFile().toPath().equals(holdingFolder.getCanonicalFile().toPath()))
                 return true;
 
             testFile = testFile.getParentFile();


### PR DESCRIPTION

This PR fixes a potential security vulnerability in `isFileWithinParent` that was cloned from https://github.com/jlangch/venice/commit/c942c73136333bc493050910f171a48e6f575b23 but did not receive the security patch.

### Details:
Affected Function: `isFileWithinParent` in src/net/highwayfrogs/editor/utils/FileUtils.java
Original Fix: https://github.com/jlangch/venice/commit/c942c73136333bc493050910f171a48e6f575b23

Replace the current comparison, which is vulnerable to partial path traversal attacks, with the more secure one.

### What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

### References:
- https://github.com/jlangch/venice/commit/c942c73136333bc493050910f171a48e6f575b23
- https://nvd.nist.gov/vuln/detail/CVE-2022-36007

Please review and merge this PR to ensure your repository is protected against this potential vulnerability.
