### PR TITLE
Corrected mm3d normals when importing

### DIFF
--- a/src/net/highwayfrogs/editor/games/sony/shared/mof2/utils/MRModelImportUtils.java
+++ b/src/net/highwayfrogs/editor/games/sony/shared/mof2/utils/MRModelImportUtils.java
@@ -222,4 +222,37 @@ public class MRModelImportUtils {
 
         return null;
     }
+
+    /**
+     * mm3d files will create NaN normal values for misconfigured vertices.
+     * Since you cannot check normals within the software, zero out any NaN so the import can still succeed
+     * @param x The X value of the new SVector
+     * @param y The Y value of the new SVector
+     * @param z The Z value of the new SVector
+     * @param errorMessage The error message if any NaN are found. Used instead of a direct logger to limit # of messages
+     * @param identifier string appended to any error message to help identify the vector
+     * @return A new SVector with no NaN
+     */
+    public static SVector newSVectorZeroOutNaN(float x, float y, float z, StringBuilder errorMessage, String identifier) {
+        float[] og = {x, y, z};
+        boolean foundNaN = false;
+        if (Float.isNaN(x)) {
+            x = 0;
+            foundNaN = true;
+        }
+        if (Float.isNaN(y)) {
+            y = 0;
+            foundNaN = true;
+        }
+        if (Float.isNaN(z)) {
+            z = 0;
+            foundNaN = true;
+        }
+
+        if (foundNaN && errorMessage != null) {
+           errorMessage.append(String.format("%s Values: (%s, %s, %s) ", identifier, og[0], og[1], og[2]));
+        }
+
+        return new SVector(x, y, z);
+    }
 }

--- a/src/net/highwayfrogs/editor/games/sony/shared/mof2/utils/MRModelImportUtils.java
+++ b/src/net/highwayfrogs/editor/games/sony/shared/mof2/utils/MRModelImportUtils.java
@@ -255,4 +255,17 @@ public class MRModelImportUtils {
 
         return new SVector(x, y, z);
     }
+
+    /**
+     * Normalizes the vector by finding the current magnitude and then multiplying to the desired magnitude
+     * Frogger uses normals of magnitude 256 for the models, but they are often not imported as such
+     * @param vector The SVector to normalize
+     * @param magnitude The desired magnitude of the vector
+     * @return normalized SVector
+     */
+    public static SVector normalizeVectorToMagnitude(SVector vector, double magnitude) {
+        double currentLength = Math.sqrt(vector.getFloatX() * vector.getFloatX() + vector.getFloatY() * vector.getFloatY() + vector.getFloatZ() * vector.getFloatZ());
+        double targetMultiplier = magnitude / currentLength;
+        return vector.multiply(targetMultiplier);
+    }
 }

--- a/src/net/highwayfrogs/editor/games/sony/shared/mof2/utils/MRMofAndMisfitModelConverter.java
+++ b/src/net/highwayfrogs/editor/games/sony/shared/mof2/utils/MRMofAndMisfitModelConverter.java
@@ -593,9 +593,10 @@ public class MRMofAndMisfitModelConverter {
 
                 StringBuilder errorMessage = new  StringBuilder();
                 // Normals from mm3d can be NaN, but normals are mostly for lighting. Set NaN to zero to avoid errors
-                SVector n1 = MRModelImportUtils.newSVectorZeroOutNaN(block.getV1Normals()[0], block.getV1Normals()[1], -block.getV1Normals()[2], errorMessage, "n1");
+                // Normals are also in reverse order: rearrange them here
+                SVector n1 = MRModelImportUtils.newSVectorZeroOutNaN(block.getV3Normals()[0], block.getV3Normals()[1], -block.getV3Normals()[2], errorMessage, "n1");
                 // mm3d uses normal ranges from -1 to 1, but Frogger uses -256 to 256. Without changing this, parallel lighting is near black
-                n1.multiply(256);
+                n1 = MRModelImportUtils.normalizeVectorToMagnitude(n1, 256.0);
                 if ((temp = normalIndices.get(n1)) == null) {
                     normalIndices.put(n1, temp = staticPartCel.getNormals().size());
                     staticPartCel.getNormals().add(n1);
@@ -603,15 +604,15 @@ public class MRMofAndMisfitModelConverter {
                 trackedIndices[0] = temp;
 
                 SVector n2 = MRModelImportUtils.newSVectorZeroOutNaN(block.getV2Normals()[0], block.getV2Normals()[1], -block.getV2Normals()[2], errorMessage, "n2");
-                n2.multiply(256);
+                n2 = MRModelImportUtils.normalizeVectorToMagnitude(n2, 256.0);
                 if ((temp = normalIndices.get(n2)) == null) {
                     normalIndices.put(n2, temp = staticPartCel.getNormals().size());
                     staticPartCel.getNormals().add(n2);
                 }
                 trackedIndices[1] = temp;
 
-                SVector n3 = MRModelImportUtils.newSVectorZeroOutNaN(block.getV3Normals()[0], block.getV3Normals()[1], -block.getV3Normals()[2], errorMessage, "n3");
-                n3.multiply(256);
+                SVector n3 = MRModelImportUtils.newSVectorZeroOutNaN(block.getV1Normals()[0], block.getV1Normals()[1], -block.getV1Normals()[2], errorMessage, "n3");
+                n3 = MRModelImportUtils.normalizeVectorToMagnitude(n3, 256.0);
                 if ((temp = normalIndices.get(n3)) == null) {
                     normalIndices.put(n3, temp = staticPartCel.getNormals().size());
                     staticPartCel.getNormals().add(n3);

--- a/src/net/highwayfrogs/editor/games/sony/shared/mof2/utils/MRMofAndMisfitModelConverter.java
+++ b/src/net/highwayfrogs/editor/games/sony/shared/mof2/utils/MRMofAndMisfitModelConverter.java
@@ -591,26 +591,37 @@ public class MRMofAndMisfitModelConverter {
             for (MMTriangleNormalsBlock block : jointNormals) {
                 int[] trackedIndices = new int[3];
 
-                SVector n1 = new SVector(-block.getV1Normals()[0], -block.getV1Normals()[1], block.getV1Normals()[2]);
+                StringBuilder errorMessage = new  StringBuilder();
+                // Normals from mm3d can be NaN, but normals are mostly for lighting. Set NaN to zero to avoid errors
+                SVector n1 = MRModelImportUtils.newSVectorZeroOutNaN(block.getV1Normals()[0], block.getV1Normals()[1], -block.getV1Normals()[2], errorMessage, "n1");
+                // mm3d uses normal ranges from -1 to 1, but Frogger uses -256 to 256. Without changing this, parallel lighting is near black
+                n1.multiply(256);
                 if ((temp = normalIndices.get(n1)) == null) {
                     normalIndices.put(n1, temp = staticPartCel.getNormals().size());
                     staticPartCel.getNormals().add(n1);
                 }
                 trackedIndices[0] = temp;
 
-                SVector n2 = new SVector(-block.getV2Normals()[0], -block.getV2Normals()[1], block.getV2Normals()[2]);
+                SVector n2 = MRModelImportUtils.newSVectorZeroOutNaN(block.getV2Normals()[0], block.getV2Normals()[1], -block.getV2Normals()[2], errorMessage, "n2");
+                n2.multiply(256);
                 if ((temp = normalIndices.get(n2)) == null) {
                     normalIndices.put(n2, temp = staticPartCel.getNormals().size());
                     staticPartCel.getNormals().add(n2);
                 }
                 trackedIndices[1] = temp;
 
-                SVector n3 = new SVector(-block.getV3Normals()[0], -block.getV3Normals()[1], block.getV3Normals()[2]);
+                SVector n3 = MRModelImportUtils.newSVectorZeroOutNaN(block.getV3Normals()[0], block.getV3Normals()[1], -block.getV3Normals()[2], errorMessage, "n3");
+                n3.multiply(256);
                 if ((temp = normalIndices.get(n3)) == null) {
                     normalIndices.put(n3, temp = staticPartCel.getNormals().size());
                     staticPartCel.getNormals().add(n3);
                 }
                 trackedIndices[2] = temp;
+
+                // We only want one error message per face, since all NaN is likely when there is at least one NaN
+                if (errorMessage.length() > 0) {
+                    logger.warning(errorMessage.insert(0, "NaN in normal vector detected! Setting to 0 so the import can succeed. ").append("Index: ").append(block.getTriangleIndex()).toString());
+                }
 
                 partCelNormalIdsByNormalBlock.put(block, trackedIndices);
             }


### PR DESCRIPTION
mm3d imports with corrected normals now, allowing for parallel lighting to work correctly.

What changed:
- Normal vectors normalized to 256 magnitude (used to be 1 magnitude)
- Normals were inverted
- Normals from incoming triangle faces reordered from 1, 2, 3 to 3, 2, 1