### PR TITLE
Updated Tooltips and Parameter Descriptions

### DIFF
--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/cave/FroggerEntityDataFatFireFly.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/cave/FroggerEntityDataFatFireFly.java
@@ -49,6 +49,12 @@ public class FroggerEntityDataFatFireFly extends FroggerEntityDataMatrix impleme
             this.flyType = newType;
             manager.updateEntityMesh(getParentEntity());
         }).setTooltip(FXUtils.createTooltip("Changing this value will not alter the fly's appearance, but will change its collection properties.\nIntended value is SUPER_LIGHT."));
+        editor.addSeparator(25);
         editor.addFloatSVector("Target (Unused)", this.target, manager.getController());
+        editor.addNormalLabel("Leftover of a scrapped feature that");
+        editor.addNormalLabel("would pan the camera to this location.");
+        editor.addNormalLabel("Can be reimplemented using the source");
+        editor.addNormalLabel("code, but is prone to breaking the");
+        editor.addNormalLabel("cave light.");
     }
 }

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/cave/FroggerEntityDataFatFireFly.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/cave/FroggerEntityDataFatFireFly.java
@@ -48,7 +48,7 @@ public class FroggerEntityDataFatFireFly extends FroggerEntityDataMatrix impleme
         editor.addEnumSelector("Fly Score Type", this.flyType, FroggerFlyScoreType.values(), false, newType -> {
             this.flyType = newType;
             manager.updateEntityMesh(getParentEntity());
-        }).setTooltip(FXUtils.createTooltip("This has never been tested as anything other than SUPER_LIGHT."));
+        }).setTooltip(FXUtils.createTooltip("Changing this value will not alter the fly's appearance, but will change its collection properties.\nIntended value is SUPER_LIGHT."));
         editor.addFloatSVector("Target (Unused)", this.target, manager.getController());
     }
 }

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/cave/FroggerEntityDataRaceSnail.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/cave/FroggerEntityDataRaceSnail.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import net.highwayfrogs.editor.games.sony.frogger.map.FroggerMapFile;
 import net.highwayfrogs.editor.games.sony.frogger.map.data.entity.data.FroggerEntityDataPathInfo;
 import net.highwayfrogs.editor.gui.GUIEditorGrid;
+import net.highwayfrogs.editor.utils.FXUtils;
 import net.highwayfrogs.editor.utils.data.reader.DataReader;
 import net.highwayfrogs.editor.utils.data.writer.DataWriter;
 
@@ -38,7 +39,7 @@ public class FroggerEntityDataRaceSnail extends FroggerEntityDataPathInfo {
     @Override
     public void setupEditor(GUIEditorGrid editor) {
         super.setupEditor(editor);
-        editor.addUnsignedFixedShort("Forward Distance", this.forwardDistance, newForwardDistance -> this.forwardDistance = newForwardDistance, 256);
-        editor.addUnsignedFixedShort("Backward Distance", this.backwardDistance, newBackwardDistance -> this.backwardDistance = newBackwardDistance, 256);
+        editor.addUnsignedFixedShort("Forward Distance", this.forwardDistance, newForwardDistance -> this.forwardDistance = newForwardDistance, 256).setTooltip(FXUtils.createTooltip("Controls the maximum speed of the snail. Also factors into the midpoint."));
+        editor.addUnsignedFixedShort("Backward Distance", this.backwardDistance, newBackwardDistance -> this.backwardDistance = newBackwardDistance, 256).setTooltip(FXUtils.createTooltip("Used only for adjusting the midpoint."));
     }
 }

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/desert/FroggerEntityDataCrack.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/desert/FroggerEntityDataCrack.java
@@ -44,7 +44,7 @@ public class FroggerEntityDataCrack extends FroggerEntityDataMatrix {
             textField.setTooltip(FXUtils.createTooltip("How long to wait before beginning to fall, in seconds."));
         } else {
             TextField textField = editor.addUnsignedFixedShort("Unused Fall Delay (secs)", this.fallDelay, newFallDelay -> this.fallDelay = newFallDelay, getGameInstance().getFPS());
-            textField.setTooltip(FXUtils.createTooltip("How long to wait before beginning to fall, in seconds.\nThis value seems to be unused."));
+            textField.setTooltip(FXUtils.createTooltip("The final game ties the fall delay to the animation, leaving this unused.\nCracks fall 20 frames (.67 seconds) after they are hit."));
             textField.setDisable(true); // Unused value.
         }
 

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/desert/FroggerEntityDataCrocodileHead.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/desert/FroggerEntityDataCrocodileHead.java
@@ -60,11 +60,11 @@ public class FroggerEntityDataCrocodileHead extends FroggerEntityDataMatrix {
         editor.addUnsignedFixedShort("Rise Speed (per frame)", this.riseSpeed, newRiseSpeed -> this.riseSpeed = newRiseSpeed, 256)
                 .setTooltip(FXUtils.createTooltip("How much distance should be risen each frame, while the crocodile head is rising."));
         editor.addUnsignedFixedShort("Snap Delay (secs)", this.snapDelay, newSnapDelay -> this.snapDelay = newSnapDelay, getGameInstance().getFPS())
-                .setTooltip(FXUtils.createTooltip("Controls how long (in seconds), the crocodile head will stay in the snapping phase. (Kills the player)"));
+                .setTooltip(FXUtils.createTooltip("How long the croc will idle above water before snapping.\nIf this croc cannot snap, idle time equals (Snap Delay + Pause Delay)."));
         editor.addCheckBox("Should Snap", this.shouldSnap, newSnapOrNot -> this.shouldSnap = newSnapOrNot)
                 .setTooltip(FXUtils.createTooltip("Enables occasional snapping while in the pause state."));
         editor.addUnsignedFixedShort("Pause Delay (secs)", this.pauseDelay, newPauseDelay -> this.pauseDelay = newPauseDelay, getGameInstance().getFPS())
-                .setTooltip(FXUtils.createTooltip("Controls how long the crocodile head sits above the water in a state the player can safely jump on."));
+                .setTooltip(FXUtils.createTooltip("How long the croc will idle above water after snapping, before submerging.\nIf this croc cannot snap, idle time equals (Snap Delay + Pause Delay)."));
         editor.addUnsignedFixedShort("Submerged Delay (secs)", this.submergedDelay, newSubmergedDelay -> this.submergedDelay = newSubmergedDelay, getGameInstance().getFPS())
                 .setTooltip(FXUtils.createTooltip("How the crocodile head will stay submerged before rising."));
     }

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/desert/FroggerEntityDataFallingRock.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/desert/FroggerEntityDataFallingRock.java
@@ -127,7 +127,7 @@ public class FroggerEntityDataFallingRock extends FroggerEntityDataMatrix {
             grid.addFloatVector("Bounce Target #" + (this.index + 1), this.target, null, controller,
                     (targetPos, bits) -> this.parentData.selectNewPosition(controller, targetPos, bits));
             grid.addUnsignedFixedShort("Time to Target (secs)", this.time, newTime -> this.time = newTime, getGameInstance().getFPS())
-                    .setTooltip(FXUtils.createTooltip("Controls how long it will take to reach the next boulder target from the moment Target #" + (this.index + 1) + " is reached."));
+                    .setTooltip(FXUtils.createTooltip("Controls how long it will take to reach the next boulder target from the moment Target #" + (this.index + 1) + " is reached.\nA bigger number will result in a higher bounce arc."));
         }
     }
 }

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/desert/FroggerEntityDataFallingRock.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/desert/FroggerEntityDataFallingRock.java
@@ -85,7 +85,10 @@ public class FroggerEntityDataFallingRock extends FroggerEntityDataMatrix {
             this.bounceCount = newBounceCount;
             manager.updateEditor();
         }).setTooltip(FXUtils.createTooltip("Controls how many bounces the boulder will make before it breaks/resets."));
-
+        //editor.addSeparator(25);
+        editor.addBoldLabel("Note:");
+        editor.addNormalLabel("Bounce targets are projected downwards");
+        editor.addNormalLabel("to the nearest solid ground in-game.");
         // Setup the editor for the enabled bounce targets.
         for (int i = 0; i < this.bounceCount; i++)
             this.targets[i].setupEditor(editor, manager.getController());

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/desert/FroggerEntityDataThermal.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/desert/FroggerEntityDataThermal.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import net.highwayfrogs.editor.games.sony.frogger.map.FroggerMapFile;
 import net.highwayfrogs.editor.games.sony.frogger.map.data.entity.data.FroggerEntityDataPathInfo;
 import net.highwayfrogs.editor.gui.GUIEditorGrid;
+import net.highwayfrogs.editor.utils.FXUtils;
 import net.highwayfrogs.editor.utils.data.reader.DataReader;
 import net.highwayfrogs.editor.utils.data.writer.DataWriter;
 
@@ -32,6 +33,6 @@ public class FroggerEntityDataThermal extends FroggerEntityDataPathInfo {
 
     @Override
     public void setupEditor(GUIEditorGrid editor) {
-        editor.addUnsignedFixedShort("Rotation% (per frame)", 4096 - this.rotateTime, newRotateTime -> this.rotateTime = 4096 - newRotateTime, 4096, 0, 4096);
+        editor.addUnsignedFixedShort("Rotation% (per frame)", 4096 - this.rotateTime, newRotateTime -> this.rotateTime = 4096 - newRotateTime, 4096, 0, 4096).setTooltip(FXUtils.createTooltip("Controls how fast the thermal will spin while it travels."));
     }
 }

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/forest/FroggerEntityDataBreakingBranch.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/forest/FroggerEntityDataBreakingBranch.java
@@ -42,7 +42,7 @@ public class FroggerEntityDataBreakingBranch extends FroggerEntityDataMatrix {
         super.setupEditor(editor);
         editor.addUnsignedFixedShort("Break Delay (secs)", this.breakDelay, newBreakDelay -> this.breakDelay = newBreakDelay, getGameInstance().getFPS(), 0, 3000)
                 .setTooltip(FXUtils.createTooltip("How long does it take from the moment the player steps on the branch for it to become unusable?"));
-        editor.addUnsignedFixedShort("Fall Speed (grid/sec)", this.fallSpeed, newFallSpeed -> this.fallSpeed = newFallSpeed, 2184.5)
-                .setTooltip(FXUtils.createTooltip("How fast the branch falls once it breaks.\nThe unit of this value is not correctly understood."));
+        editor.addUnsignedFixedShort("Unused Fall Speed", this.fallSpeed, newFallSpeed -> this.fallSpeed = newFallSpeed, 2184.5)
+                .setTooltip(FXUtils.createTooltip("Unused in favor of a hardcoded gravity equation."));
     }
 }

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/forest/FroggerEntityDataHedgehog.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/forest/FroggerEntityDataHedgehog.java
@@ -49,9 +49,9 @@ public class FroggerEntityDataHedgehog extends FroggerEntityDataPathInfo {
                 .setTooltip(FXUtils.createTooltip("How long the hedgehog runs before entering into a roll.\nIMPORTANT: Hedgehogs are set to running when they restart at the beginning of a path."));
         editor.addUnsignedFixedShort("Roll Time (sec)", this.rollTime, newRollTime -> this.rollTime = newRollTime, getGameInstance().getFPS())
                 .setTooltip(FXUtils.createTooltip("How long the hedgehog rolls before it enters into a run.\nIMPORTANT: Hedgehogs are set to running when they restart at the beginning of a path."));
-        editor.addUnsignedFixedShort("Run Speed (grid sq/sec)", this.runSpeed, newRunSpeed -> this.runSpeed = newRunSpeed, 16)
+        editor.addUnsignedFixedShort("Run Speed (distance/frame)", this.runSpeed, newRunSpeed -> this.runSpeed = newRunSpeed, 16)
                 .setTooltip(FXUtils.createTooltip("This is the path speed used while the hedgehog is running."));
-        editor.addUnsignedFixedShort("Roll Speed (grid sq/sec)", this.rollSpeed, newRollSpeed -> this.rollSpeed = newRollSpeed, 16)
+        editor.addUnsignedFixedShort("Roll Speed (distance/frame)", this.rollSpeed, newRollSpeed -> this.rollSpeed = newRollSpeed, 16)
                 .setTooltip(FXUtils.createTooltip("This is the path speed used while the hedgehog is rolling."));
     }
 }

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/forest/FroggerEntityDataSquirrel.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/forest/FroggerEntityDataSquirrel.java
@@ -37,8 +37,8 @@ public class FroggerEntityDataSquirrel extends FroggerEntityDataPathInfo {
     public void setupEditor(GUIEditorGrid editor) {
         super.setupEditor(editor);
         // Seems unused.
-        TextField squirrelTurnDurationField = editor.addUnsignedFixedShort("Turn Duration (secs)", this.turnDuration, newTurnDuration -> this.turnDuration = newTurnDuration, getGameInstance().getFPS(), 0, 3000);
+        TextField squirrelTurnDurationField = editor.addUnsignedFixedShort("Unused Turn Duration (secs)", this.turnDuration, newTurnDuration -> this.turnDuration = newTurnDuration, getGameInstance().getFPS(), 0, 3000);
         squirrelTurnDurationField.setDisable(true);
-        squirrelTurnDurationField.setTooltip(FXUtils.createTooltip("Controls how long the squirrel's turn lasts.\nSeems unused in favor of automatically checking when the turn animation is finished."));
+        squirrelTurnDurationField.setTooltip(FXUtils.createTooltip("Controls how long the squirrel's turn lasts.\nUnused in favor of automatically checking when the turn animation is finished. This animation lasts 21 frames (.7 seconds)."));
     }
 }

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/forest/FroggerEntityDataSwayingBranch.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/forest/FroggerEntityDataSwayingBranch.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import net.highwayfrogs.editor.games.sony.frogger.map.FroggerMapFile;
 import net.highwayfrogs.editor.games.sony.frogger.map.data.entity.data.FroggerEntityDataMatrix;
 import net.highwayfrogs.editor.gui.GUIEditorGrid;
+import net.highwayfrogs.editor.utils.FXUtils;
 import net.highwayfrogs.editor.utils.data.reader.DataReader;
 import net.highwayfrogs.editor.utils.data.writer.DataWriter;
 
@@ -42,9 +43,9 @@ public class FroggerEntityDataSwayingBranch extends FroggerEntityDataMatrix {
     @Override
     public void setupEditor(GUIEditorGrid editor) {
         super.setupEditor(editor);
-        editor.addUnsignedFixedShort("Sway Angle (degrees)", this.swayAngle, newSwayAngle -> this.swayAngle = newSwayAngle, 1, 0, 360);
-        editor.addUnsignedFixedShort("Sway (percent/frame)", this.swayDuration, newSwayDuration -> this.swayDuration = newSwayDuration, 1024, 0, 1024);
+        editor.addUnsignedFixedShort("Sway Angle (degrees)", this.swayAngle, newSwayAngle -> this.swayAngle = newSwayAngle, 1, 0, 360).setTooltip(FXUtils.createTooltip("Controls how far the branch will swing.\nIt will swing half of this distance in either direction from its initial position. Branches always swing clockwise first."));
+        editor.addUnsignedFixedShort("Sway Duration (secs)", this.swayDuration, newSwayDuration -> this.swayDuration = newSwayDuration, getGameInstance().getFPS()).setTooltip(FXUtils.createTooltip("Controls how long the branch will take to swing from one side to the other."));
         if (!getConfig().isAtOrBeforeBuild11() && !getConfig().isWindowsBeta())
-            editor.addUnsignedFixedShort("Once Off Delay", this.onceOffDelay, newOnceOffDelay -> this.onceOffDelay = newOnceOffDelay, 30);
+            editor.addUnsignedFixedShort("Delay (secs)", this.onceOffDelay, newOnceOffDelay -> this.onceOffDelay = newOnceOffDelay, 30).setTooltip(FXUtils.createTooltip("Controls how long to wait after the level loads to start swaying."));
     }
 }

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/general/FroggerEntityDataBonusFly.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/general/FroggerEntityDataBonusFly.java
@@ -51,6 +51,42 @@ public class FroggerEntityDataBonusFly extends FroggerEntityDataMatrix implement
                 if (manager != null)
                     manager.updateEntityMesh(getParentEntity());
             });
+            editor.addBoldLabel("SCORE_X:");
+            editor.addNormalLabel("Adds X amount to the player's score.");
+            editor.addBoldLabel("LIGHT_BOOST:");
+            editor.addNormalLabel("Provides a small boost to the player's light.");
+            editor.addNormalLabel("Only useful in Cave levels.");
+            editor.addBoldLabel("SUPER_LIGHT:");
+            editor.addNormalLabel("Provides a huge boost to the player's light");
+            editor.addNormalLabel("Only useful in Cave levels.");
+            editor.addNormalLabel("For unique flying pattern and sound effects,");
+            editor.addNormalLabel("use CAV_FAT_FIRE_FLY instead.");
+            editor.addBoldLabel("TIME_MIN/MED/MAX:");
+            editor.addNormalLabel("Adds 2/5/10 seconds to the timer.");
+            editor.addNormalLabel("Caps at 75 seconds on PSX, and 99 on PC.");
+            editor.addNormalLabel("Hardcoded to respawn every new life.");
+            editor.addBoldLabel("REDUCE_SCORE_100:");
+            editor.addNormalLabel("Subtracts *500* points from the player's score.");
+            editor.addNormalLabel("Attempting to go below 0 will briefly glitch");
+            editor.addNormalLabel("the score, awarding the next 10,000 point 1UP.");
+            editor.addBoldLabel("FAST_TIMER_SPEED:");
+            editor.addNormalLabel("Causes the level timer to decrease much");
+            editor.addNormalLabel("faster for a short duration.");
+            editor.addNormalLabel("Loses roughly 8 seconds of time.");
+            editor.addBoldLabel("ADD_EXTRA_LIFE:");
+            editor.addNormalLabel("Adds 1 life to the player's total.");
+            editor.addNormalLabel("Cannot exceed 10 lives.");
+            editor.addBoldLabel("FROG_SUPER_TONGUE:");
+            editor.addNormalLabel("Doubles the range of the player's tongue.");
+            editor.addNormalLabel("Lasts for 15 seconds.");
+            editor.addBoldLabel("FROG_QUICK_JUMP:");
+            editor.addNormalLabel("Doubles the player's normal jump speed.");
+            editor.addNormalLabel("Lasts for 8 seconds.");
+            editor.addBoldLabel("FROG_AUTO_HOP:");
+            editor.addNormalLabel("Allows directions to be held down for");
+            editor.addNormalLabel("continuous movement. Lasts for 10 seconds.");
+            editor.addNormalLabel("Points will not be gained for normal");
+            editor.addNormalLabel("hops while active.");
         } else {
             editor.addSignedIntegerField("Fly Score Type ID", this.flyTypeId, newTypeId -> {
                 this.flyTypeId = newTypeId;

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/jungle/FroggerEntityDataEvilPlant.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/jungle/FroggerEntityDataEvilPlant.java
@@ -39,8 +39,8 @@ public class FroggerEntityDataEvilPlant extends FroggerEntityDataMatrix {
     public void setupEditor(GUIEditorGrid editor) {
         super.setupEditor(editor);
         editor.addFixedShort("Snap Time (sec)", this.snapTime, newSnapTime -> this.snapTime = newSnapTime, getGameInstance().getFPS())
-                .setTooltip(FXUtils.createTooltip("How long to wait to start snapping after the player enters aggro range."));
+                .setTooltip(FXUtils.createTooltip("How long to wait to start snapping after the player enters aggro range.\nThe plant will additionally pause for this amount of time once the Snap Delay expires."));
         editor.addFixedShort("Snap Delay (sec)", this.snapDelay, newSnapDelay -> this.snapDelay = newSnapDelay, getGameInstance().getFPS())
-                .setTooltip(FXUtils.createTooltip("After the snap animation ends, the plant will be incapacitated until this delay ends."));
+                .setTooltip(FXUtils.createTooltip("How long the plant will continue to snap at the player before pausing.\nThis timer starts after the plant has finished its first bite."));
     }
 }

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/jungle/FroggerEntityDataRopeBridge.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/jungle/FroggerEntityDataRopeBridge.java
@@ -39,9 +39,9 @@ public class FroggerEntityDataRopeBridge extends FroggerEntityDataMatrix {
     @Override
     public void setupEditor(GUIEditorGrid editor) {
         super.setupEditor(editor);
-        TextField textField = editor.addUnsignedFixedShort("Unused Fall Delay (secs)", this.fallDelay, newFallDelay -> this.fallDelay = newFallDelay, getGameInstance().getFPS());
-        textField.setTooltip(FXUtils.createTooltip("How long to wait before beginning to fall, in seconds.\nThis value seems to be unused."));
-        textField.setDisable(true); // Unused value.
+        TextField textField = editor.addUnsignedFixedShort("Fall Delay (secs)", this.fallDelay, newFallDelay -> this.fallDelay = newFallDelay, getGameInstance().getFPS());
+        textField.setTooltip(FXUtils.createTooltip("How long to wait before falling\nStarts counting once \"Hops Before Break\" has been met."));
+        //textField.setDisable(true); // Unused value. (No it isn't :P)
 
         editor.addUnsignedShortField("Hops Before Break", this.hopsBeforeBreak, newHopsBeforeBreak -> this.hopsBeforeBreak = newHopsBeforeBreak)
                 .setTooltip(FXUtils.createTooltip("How many times does the player need to jump on the bridge before it breaks?\n0 is treated as an instant break just like 1."));

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/retro/FroggerEntityDataBabyFrog.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/retro/FroggerEntityDataBabyFrog.java
@@ -1,6 +1,7 @@
 package net.highwayfrogs.editor.games.sony.frogger.map.data.entity.data.retro;
 
 import javafx.scene.control.Alert.AlertType;
+import javafx.scene.control.TextField;
 import lombok.Getter;
 import net.highwayfrogs.editor.games.sony.frogger.map.FroggerMapFile;
 import net.highwayfrogs.editor.games.sony.frogger.map.data.entity.FroggerMapEntity;
@@ -53,8 +54,10 @@ public class FroggerEntityDataBabyFrog extends FroggerEntityDataMatrix {
 
             return true;
         }, newLogId -> this.logId = newLogId).setTooltip(FXUtils.createTooltip("The unique ID of the entity which the baby frog should ride."));
-        editor.addSignedShortField("Points (Unused?)", this.awardedPoints, newAwardedPoints -> this.awardedPoints = newAwardedPoints)
-                .setDisable(true);
+        TextField textField = editor.addSignedShortField("Points (Unused)", this.awardedPoints, newAwardedPoints -> this.awardedPoints = newAwardedPoints);
+        textField.setTooltip(FXUtils.createTooltip("This value is never used in the code. Pink baby frogs are hardcoded to give 500 points when brought to a checkpoint.\nGold baby frogs give their usual 1000 on first contact."));
+            //textField.setTooltip(FXUtils.createTooltip("This value is never used in the code.\nThis will give 1000 points like a normal gold frog.")); Couldn't figure out how to distinguish gold and pink baby frogs here, lumping both tooltips into 1 for now
+        textField.setDisable(true);
     }
 
     private String getErrorMessageForEntityId(int logEntityId) {

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/retro/FroggerEntityDataLogSnake.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/retro/FroggerEntityDataLogSnake.java
@@ -45,7 +45,7 @@ public class FroggerEntityDataLogSnake extends FroggerEntityDataMatrix {
     @Override
     public void setupEditor(GUIEditorGrid editor) {
         super.setupEditor(editor);
-        editor.addSignedShortField("Log ID", this.logId, newLogId -> {
+        editor.addSignedShortField("Ridden Entity ID", this.logId, newLogId -> {
             String errorMessage = getErrorMessageForEntityId(newLogId);
             if (errorMessage != null) {
                 FXUtils.makePopUp(errorMessage, AlertType.WARNING);
@@ -54,14 +54,14 @@ public class FroggerEntityDataLogSnake extends FroggerEntityDataMatrix {
 
             return true;
         }, newLogId -> this.logId = newLogId).setTooltip(FXUtils.createTooltip("The unique ID of the entity which the snake should ride."));
-        editor.addUnsignedFixedShort("Speed", this.speed, newSpeed -> this.speed = newSpeed, 2184.5)
-                .setTooltip(FXUtils.createTooltip("How fast along the log the snake moves. Seems to be roughly measured in grid squares per second."));
+        editor.addUnsignedFixedShort("Speed (grid sq./sec)", this.speed, newSpeed -> this.speed = newSpeed, 2184.5)
+                .setTooltip(FXUtils.createTooltip("How fast the snake moves along its ridden entity."));
     }
 
     private String getErrorMessageForEntityId(int logEntityId) {
         FroggerMapEntity foundEntity = getMapFile().getEntityPacket().getEntityByUniqueId(logEntityId);
         if (foundEntity == null)
-            return "No ridable entity (for the snake) was found with the unique ID: " + logEntityId + ".";
+            return "No rideable entity (for the snake) was found with the unique ID: " + logEntityId + ".";
         if (!"MOVING".equals(foundEntity.getTypeName()) && foundEntity.getPathInfo() == null) // The snake entity specifically uses path data.
             return "Cannot attach snake entity to a(n) " + foundEntity.getTypeName() + " entity, only path followers are allowed.";
         return null;

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/suburbia/FroggerEntityDataDog.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/suburbia/FroggerEntityDataDog.java
@@ -36,6 +36,6 @@ public class FroggerEntityDataDog extends FroggerEntityDataPathInfo {
     public void setupEditor(GUIEditorGrid editor) {
         super.setupEditor(editor);
         editor.addFixedInt("Wait Delay (sec)", this.waitDelay, newWaitDelay -> this.waitDelay = newWaitDelay, getGameInstance().getFPS())
-                .setTooltip(FXUtils.createTooltip("How long to wait in the dog kennel before running out."));
+                .setTooltip(FXUtils.createTooltip("How long to wait in the dog kennel (end of path) before running out.\nDogs only stop if \"Reverse\" path behavior is used."));
     }
 }

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/swamp/FroggerEntityDataCrusher.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/swamp/FroggerEntityDataCrusher.java
@@ -45,10 +45,11 @@ public class FroggerEntityDataCrusher extends FroggerEntityDataMatrix {
     @Override
     public void setupEditor(GUIEditorGrid editor) {
         super.setupEditor(editor);
-        editor.addFixedShort("Speed (World Units/sec)", this.speed, newSpeed -> this.speed = newSpeed, 2184.5)
-                .setTooltip(FXUtils.createTooltip("Controls how fast the crusher moves.\nMost likely these are in world units."));
+        editor.addFixedShort("Speed (grid tiles/sec)", this.speed, newSpeed -> this.speed = newSpeed, 2184.5)
+                .setTooltip(FXUtils.createTooltip("How fast the crusher moves, both extending and retracting."));
         editor.addFixedShort("Distance (grid)", this.distance, newDistance -> this.distance = newDistance, 256)
-                .setTooltip(FXUtils.createTooltip("Controls many grid squares does the crusher has moved when it is fully extended."));
+                .setTooltip(FXUtils.createTooltip("How far the crusher will extend outwards before retracting.\n\"Controls many grid squares does the crusher has moved when it is fully extended.\" \n" +
+                        "\t\\ Kneesnap, May 6, 2025"));
         editor.addEnumSelector("Movement Direction", this.direction, FroggerEntityDataCrusherDirection.values(), false, newDirection -> this.direction = newDirection)
                 .setTooltip(FXUtils.createTooltip("Controls which direction the crusher moves, from its starting position."));
         editor.addFixedShort("Delay (secs)", this.delay, newDelay -> this.delay = newDelay, getGameInstance().getFPS())

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/swamp/FroggerEntityDataPress.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/swamp/FroggerEntityDataPress.java
@@ -44,10 +44,11 @@ public class FroggerEntityDataPress extends FroggerEntityDataMatrix {
     @Override
     public void setupEditor(GUIEditorGrid editor) {
         super.setupEditor(editor);
-        editor.addFixedShort("Speed (World Units/sec)", this.speed, newSpeed -> this.speed = newSpeed, 2184.5)
-                .setTooltip(FXUtils.createTooltip("Controls how fast the press moves.\nMost likely these are in world units."));
+        editor.addFixedShort("Speed (grid tiles/sec)", this.speed, newSpeed -> this.speed = newSpeed, 2184.5)
+                .setTooltip(FXUtils.createTooltip("How fast the press moves, both rising and falling."));
         editor.addFixedShort("Distance (grid)", this.distance, newDistance -> this.distance = newDistance, 256)
-                .setTooltip(FXUtils.createTooltip("Controls many grid squares does the press has moved when it is fully extended."));
+                .setTooltip(FXUtils.createTooltip("How far the press will rise/fall before reversing course.\n\"Controls many grid squares does the press has moved when it is fully extended.\" \n" +
+                        "\t\\ Kneesnap, May 6, 2025"));
         editor.addEnumSelector("Movement Direction", this.direction, FroggerEntityDataPressDirection.values(), false, newDirection -> this.direction = newDirection)
                 .setTooltip(FXUtils.createTooltip("Controls which direction the press moves, from its starting position."));
         editor.addFixedShort("Delay (secs)", this.delay, newDelay -> this.delay = newDelay, getGameInstance().getFPS())

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/swamp/FroggerEntityDataRat.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/swamp/FroggerEntityDataRat.java
@@ -52,8 +52,8 @@ public class FroggerEntityDataRat extends FroggerEntityDataMatrix {
     @Override
     public void setupEditor(GUIEditorGrid editor) {
         super.setupEditor(editor);
-        editor.addFixedShort("Speed (World Units/sec)", this.speed, newSpeed -> this.speed = newSpeed, 256)
-                .setTooltip(FXUtils.createTooltip("Controls how fast the rat moves"));
+        editor.addFixedShort("Speed (grid tiles/sec)", this.speed, newSpeed -> this.speed = newSpeed, 256)
+                .setTooltip(FXUtils.createTooltip("Controls how fast the rat moves. Only affects the speed of the \"running\" phase."));
     }
 
     @Override

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/swamp/FroggerEntityDataRat.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/swamp/FroggerEntityDataRat.java
@@ -59,13 +59,20 @@ public class FroggerEntityDataRat extends FroggerEntityDataMatrix {
     @Override
     public void setupEditor(GUIEditorGrid editor, FroggerUIMapEntityManager manager) {
         super.setupEditor(editor, manager);
+        editor.addSeparator(25);
+        editor.addNormalLabel("Where the rat will begin its first jump.");
         editor.addFloatVector("Start Target", this.startTarget, null, manager.getController(),
                 (targetPos, bits) -> selectNewPosition(manager.getController(), targetPos, bits));
+        editor.addNormalLabel("Where the rat's first jump will land.");
+        editor.addNormalLabel("The rat will stop and roll here.");
         editor.addFloatVector("Start Run Target", this.startRunTarget, null, manager.getController(),
                 (targetPos, bits) -> selectNewPosition(manager.getController(), targetPos, bits));
+        editor.addNormalLabel("Where the rat will run to after it recovers.");
         editor.addFloatVector("End Run Target", this.endRunTarget, null, manager.getController(),
                 (targetPos, bits) -> selectNewPosition(manager.getController(), targetPos, bits));
+        editor.addNormalLabel("Where the rat will jump to after running.");
         editor.addFloatVector("End Target", this.endTarget, null, manager.getController(),
                 (targetPos, bits) -> selectNewPosition(manager.getController(), targetPos, bits));
+
     }
 }

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/swamp/FroggerEntityDataSlug.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/swamp/FroggerEntityDataSlug.java
@@ -36,7 +36,7 @@ public class FroggerEntityDataSlug extends FroggerEntityDataPathInfo {
     public void setupEditor(GUIEditorGrid editor) {
         super.setupEditor(editor);
         editor.addEnumSelector("Motion Type", this.motionType, FroggerEntityDataSlugMotionType.values(), false, newMotionType -> this.motionType = newMotionType)
-                .setTooltip(FXUtils.createTooltip("Controls if the slug movement type is ground-based or pipe-based. (Compare Bang Bang Barrel vs Slime Sliding)"));
+                .setTooltip(FXUtils.createTooltip("Controls if the slug movement type is ground-based or pipe-based. (Compare Bang Bang Barrel vs Slime Sliding)\n\"Curvy\" is best paired with the \"Local Align\" flag."));
     }
 
     public enum FroggerEntityDataSlugMotionType {

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/swamp/FroggerEntityDataSquirt.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/swamp/FroggerEntityDataSquirt.java
@@ -52,6 +52,9 @@ public class FroggerEntityDataSquirt extends FroggerEntityDataMatrix {
     @Override
     public void setupEditor(GUIEditorGrid editor, FroggerUIMapEntityManager manager) {
         super.setupEditor(editor, manager);
+        editor.addSeparator(25);
+        editor.addNormalLabel("The position the squirt will travel to.");
+        editor.addNormalLabel("It will reset once it reaches this spot.");
         editor.addFloatVector("Target", this.target, null, manager.getController(),
                 (targetPos, bits) -> selectNewPosition(manager.getController(), targetPos, bits));
     }

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/swamp/FroggerEntityDataSquirt.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/swamp/FroggerEntityDataSquirt.java
@@ -46,7 +46,7 @@ public class FroggerEntityDataSquirt extends FroggerEntityDataMatrix {
         editor.addFixedShort("Load Delay (secs)", this.timeDelay, newTimeDelay -> this.timeDelay = newTimeDelay, getGameInstance().getFPS())
                 .setTooltip(FXUtils.createTooltip("Controls how long to wait from when the level is loaded to start falling."));
         editor.addFixedShort("Drop Time (secs)", this.dropTime, newDropTime -> this.dropTime = newDropTime, getGameInstance().getFPS())
-                .setTooltip(FXUtils.createTooltip("Controls how long the squirt falls before it resets to its initial height."));
+                .setTooltip(FXUtils.createTooltip("Controls how long the squirt will take to reach the Target position."));
     }
 
     @Override

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/volcano/FroggerEntityDataColorTrigger.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/volcano/FroggerEntityDataColorTrigger.java
@@ -62,10 +62,10 @@ public class FroggerEntityDataColorTrigger extends FroggerEntityDataMatrix {
     public void setupEditor(GUIEditorGrid editor) {
         super.setupEditor(editor);
         editor.addEnumSelector("Action", this.type, FroggerEntityColorTriggerType.values(), false, newType -> this.type = newType)
-                .setTooltip(FXUtils.createTooltip("Controls what happens to the entities targetted by the switch when pressed."));
+                .setTooltip(FXUtils.createTooltip("Controls what happens to the entities targeted by the switch when pressed."));
 
         ComboBox<?> colorField = editor.addEnumSelector("Color (PSX Only)", this.color, VolcanoTriggerColor.values(), false, newColor -> this.color = newColor);
-        colorField.setTooltip(FXUtils.createTooltip("Sets the color to use for the switch.\nThis feature doesn't appear to do anything on the PC version. (PSX Untested)"));
+        colorField.setTooltip(FXUtils.createTooltip("Sets the color of the switch. Only RED/GREEN is used in the vanilla game.\nThe 8 unused variants toggle from a \"dark\" to a \"lit\" state when pressed, except Orange, which has 2 \"dark\" textures.\nThe white switch has a glitchy \"lit\" texture."));
         if (getGameInstance().isPC())
             colorField.setDisable(true);
 
@@ -79,7 +79,7 @@ public class FroggerEntityDataColorTrigger extends FroggerEntityDataMatrix {
                 }
 
                 return true;
-            }, newEntityId -> this.uniqueIds[tempIndex] = newEntityId);
+            }, newEntityId -> this.uniqueIds[tempIndex] = newEntityId).setTooltip(FXUtils.createTooltip("The ID of the path object to be linked. -1 for nothing. Multiple switches can be tied to the same ID."));
         }
     }
 
@@ -96,7 +96,7 @@ public class FroggerEntityDataColorTrigger extends FroggerEntityDataMatrix {
     }
 
     public enum VolcanoTriggerColor {
-        RED, BLUE, CYAN, GREEN, ORANGE, PINK, PURPLE, RED_ALTERNATE, WHITE
+        RED_GREEN, BLUE, CYAN, GREEN, ORANGE, PINK, PURPLE, RED, WHITE
     }
 
     public enum FroggerEntityColorTriggerType {

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/volcano/FroggerEntityDataColorTrigger.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/data/volcano/FroggerEntityDataColorTrigger.java
@@ -63,7 +63,14 @@ public class FroggerEntityDataColorTrigger extends FroggerEntityDataMatrix {
         super.setupEditor(editor);
         editor.addEnumSelector("Action", this.type, FroggerEntityColorTriggerType.values(), false, newType -> this.type = newType)
                 .setTooltip(FXUtils.createTooltip("Controls what happens to the entities targeted by the switch when pressed."));
-
+        editor.addBoldLabel("FREEZE:");
+        editor.addNormalLabel("Pauses/unpauses all linked platforms.");
+        editor.addBoldLabel("REVERSE:");
+        editor.addNormalLabel("Swaps the direction of all linked");
+        editor.addNormalLabel("platforms. Works on paused ones as well.");
+        editor.addBoldLabel("FREEZE_UNUSED_DUPLICATE:");
+        editor.addNormalLabel("Exactly what it sounds like.");
+        editor.addNormalLabel("Internally named \"START\"");
         ComboBox<?> colorField = editor.addEnumSelector("Color (PSX Only)", this.color, VolcanoTriggerColor.values(), false, newColor -> this.color = newColor);
         colorField.setTooltip(FXUtils.createTooltip("Sets the color of the switch. Only RED/GREEN is used in the vanilla game.\nThe 8 unused variants toggle from a \"dark\" to a \"lit\" state when pressed, except Orange, which has 2 \"dark\" textures.\nThe white switch has a glitchy \"lit\" texture."));
         if (getGameInstance().isPC())

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/script/FroggerEntityScriptDataNoise.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/script/FroggerEntityScriptDataNoise.java
@@ -38,7 +38,7 @@ public class FroggerEntityScriptDataNoise extends FroggerEntityScriptData {
     @Override
     public void setupEditor(GUIEditorGrid editor, FroggerUIMapEntityManager manager) {
         editor.addFixedInt("Min Radius (grid)", this.minRadius, newMinRadius -> this.minRadius = newMinRadius, 256)
-                .setTooltip(FXUtils.createTooltip("The minimum distance away (in grid squares) to hear the sound from."));
+                .setTooltip(FXUtils.createTooltip("The radius (in grid squares) within which the sound will play the loudest."));
         editor.addFixedInt("Max Radius (grid)", this.maxRadius, newMaxRadius -> this.maxRadius = newMaxRadius, 256)
                 .setTooltip(FXUtils.createTooltip("The maximum distance away (in grid squares) to hear the sound from."));
     }

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/script/sky/FroggerEntityScriptDataHawk.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/script/sky/FroggerEntityScriptDataHawk.java
@@ -5,6 +5,7 @@ import net.highwayfrogs.editor.games.sony.frogger.map.FroggerMapFile;
 import net.highwayfrogs.editor.games.sony.frogger.map.data.entity.script.FroggerEntityScriptData;
 import net.highwayfrogs.editor.games.sony.frogger.map.ui.editor.central.FroggerUIMapEntityManager;
 import net.highwayfrogs.editor.gui.GUIEditorGrid;
+import net.highwayfrogs.editor.utils.FXUtils;
 import net.highwayfrogs.editor.utils.data.reader.DataReader;
 import net.highwayfrogs.editor.utils.data.writer.DataWriter;
 
@@ -35,7 +36,7 @@ public class FroggerEntityScriptDataHawk extends FroggerEntityScriptData {
 
     @Override
     public void setupEditor(GUIEditorGrid editor, FroggerUIMapEntityManager manager) {
-        editor.addFixedInt("Speed (???)", this.speed, newSpeed -> this.speed = newSpeed, 2184.5);
-        editor.addFixedInt("Aggro Range (grid)", this.aggroDistance, newAggroDistance -> this.aggroDistance = newAggroDistance, 256);
+        editor.addFixedInt("Speed (grid tiles/sec)", this.speed, newSpeed -> this.speed = newSpeed, 2184.5).setTooltip(FXUtils.createTooltip("How fast the hawk chases its target."));
+        editor.addFixedInt("Aggro Range (grid)", this.aggroDistance, newAggroDistance -> this.aggroDistance = newAggroDistance, 256).setTooltip(FXUtils.createTooltip("The detection range for the hawk. This radius follows the hawk while it moves.\nThe hawk will instantly freeze in place once it stops detecting the player."));
     }
 }

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/script/sky/FroggerEntityScriptDataHelicopter.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/script/sky/FroggerEntityScriptDataHelicopter.java
@@ -5,6 +5,7 @@ import net.highwayfrogs.editor.games.sony.frogger.map.FroggerMapFile;
 import net.highwayfrogs.editor.games.sony.frogger.map.data.entity.script.FroggerEntityScriptData;
 import net.highwayfrogs.editor.games.sony.frogger.map.ui.editor.central.FroggerUIMapEntityManager;
 import net.highwayfrogs.editor.gui.GUIEditorGrid;
+import net.highwayfrogs.editor.utils.FXUtils;
 import net.highwayfrogs.editor.utils.data.reader.DataReader;
 import net.highwayfrogs.editor.utils.data.writer.DataWriter;
 
@@ -35,7 +36,7 @@ public class FroggerEntityScriptDataHelicopter extends FroggerEntityScriptData {
 
     @Override
     public void setupEditor(GUIEditorGrid editor, FroggerUIMapEntityManager manager) {
-        editor.addFixedInt("Fly Height (grid)", this.destination, newDestination -> this.destination = newDestination, 256);
-        editor.addFixedInt("Delta (???)", this.delta, newDelta -> this.delta = newDelta, 2184.5);
+        editor.addFixedInt("Fly Height (grid)", this.destination, newDestination -> this.destination = newDestination, 256).setTooltip(FXUtils.createTooltip("How far the helicopter will travel downwards from its starting position."));
+        editor.addFixedInt("Delta (grid tiles/sec)", this.delta, newDelta -> this.delta = newDelta, 2184.5).setTooltip(FXUtils.createTooltip("How fast the helicopter will both rise and fall."));
     }
 }

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/script/swamp/FroggerEntityScriptDataNuclearBarrel.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/script/swamp/FroggerEntityScriptDataNuclearBarrel.java
@@ -39,6 +39,6 @@ public class FroggerEntityScriptDataNuclearBarrel extends FroggerEntityScriptDat
         editor.addSignedIntegerField("Jump Distance (grid)", this.jumpDistance, newDistance -> this.jumpDistance = newDistance)
                 .setTooltip(FXUtils.createTooltip("Controls how many grid squares the player will be moved."));
         editor.addFixedInt("Jump Time (sec)", this.jumpTime, newTime -> this.jumpTime = newTime, getGameInstance().getFPS())
-                .setTooltip(FXUtils.createTooltip("Controls how long (in seconds) the jump will take."));
+                .setTooltip(FXUtils.createTooltip("Controls how long (in seconds) the jump will take.\nA bigger number will result in a higher launch arc."));
     }
 }

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/script/volcano/FroggerEntityScriptDataMechanism.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/entity/script/volcano/FroggerEntityScriptDataMechanism.java
@@ -45,16 +45,19 @@ public class FroggerEntityScriptDataMechanism extends FroggerEntityScriptData {
         writer.writeInt(this.destination);
         writer.writeInt(this.initialDelay);
     }
-
+//  Refer generically as platforms, since I can't distinguish form library entries right now
     @Override
     public void setupEditor(GUIEditorGrid editor, FroggerUIMapEntityManager manager) {
-        editor.addFixedInt("Return Delay (secs)", this.returnTripDelay, newReturnTripDelay -> this.returnTripDelay = newReturnTripDelay, getGameInstance().getFPS());
-        editor.addFixedInt("Delta (???)", this.delta, newDelta -> this.delta = newDelta, 2184.5);
-        editor.addFixedInt("Direction Change Delay (secs)", this.directionChangeDelay, newDirectionChangeDelay -> this.directionChangeDelay = newDirectionChangeDelay, getGameInstance().getFPS())
-                .setTooltip(FXUtils.createTooltip("Controls how long to wait when reversing direction."));
-        editor.addFixedInt("Return Target (???)", this.returnTripDestination, newReturnTripDestination -> this.returnTripDestination = newReturnTripDestination, 2184.5);
+        editor.addFixedInt("Return Delay (secs)", this.returnTripDelay, newReturnTripDelay -> this.returnTripDelay = newReturnTripDelay, getGameInstance().getFPS())
+                .setTooltip(FXUtils.createTooltip("How long the platform will wait at its destination before rising back up."));
+        editor.addFixedInt("Fall Speed (grid tiles/sec)", this.delta, newDelta -> this.delta = newDelta, 2184.5)
+                .setTooltip(FXUtils.createTooltip("How fast the platform will move while it descends to its destination."));
+        editor.addFixedInt("Fall Delay (secs)", this.directionChangeDelay, newDirectionChangeDelay -> this.directionChangeDelay = newDirectionChangeDelay, getGameInstance().getFPS())
+                .setTooltip(FXUtils.createTooltip("How long the platform will wait at its highest point before falling again."));
+        editor.addFixedInt("Return Speed (grid tiles/sec)", this.returnTripDestination, newReturnTripDestination -> this.returnTripDestination = newReturnTripDestination, 2184.5)
+                .setTooltip(FXUtils.createTooltip("How fast the platform will move while rising to its starting position."));
         editor.addFixedInt("Destination (grid)", this.destination, newDestination -> this.destination = newDestination, 256)
-                .setTooltip(FXUtils.createTooltip("Controls how far the mechanism will move down before reversing direction. Measured in grid squares."));
+                .setTooltip(FXUtils.createTooltip("How far the platform will travel below its starting position."));
         editor.addFixedInt("Initial Delay (secs)", this.initialDelay, newInitialDelay -> this.initialDelay = newInitialDelay, getGameInstance().getFPS())
                 .setTooltip(FXUtils.createTooltip("Controls how long to wait after the map loads to start moving."));
     }

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/packets/FroggerMapFilePacketGeneral.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/packets/FroggerMapFilePacketGeneral.java
@@ -254,7 +254,7 @@ public class FroggerMapFilePacketGeneral extends FroggerMapFilePacket {
                         newStartRotation -> {
             this.startRotation = newStartRotation;
             manager.updatePlayerCharacter();                                                                                                                   //Commented out until I can figure out how to implement the tooltip alongside it
-        }).setTooltip(FXUtils.createTooltip("Which direction the frog(s) will face when they spawn. This does not affect the starting camera in any way."))    //.setConverter(new AbstractStringConverter<>(FroggerMapStartRotation::getArrow));
+        }).setTooltip(FXUtils.createTooltip("Which direction the frog(s) will face when they spawn. This does not affect the starting camera in any way."));    //.setConverter(new AbstractStringConverter<>(FroggerMapStartRotation::getArrow));
 
         // Add frog lighting data.
         if (hasFrogColorData()) {

--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/packets/FroggerMapFilePacketGeneral.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/packets/FroggerMapFilePacketGeneral.java
@@ -235,7 +235,8 @@ public class FroggerMapFilePacketGeneral extends FroggerMapFilePacket {
         // Add map theme / level timer.
         if (!isAprilFormat()) {
             editor.addLabel("Theme", getParentFile().getMapTheme().name()); // Should look into whether this is ok to edit.
-            editor.addUnsignedShortField("Level Timer", this.startingTimeLimit, newStartingTimeLimit -> this.startingTimeLimit = newStartingTimeLimit);
+            editor.addUnsignedShortField("Level Timer", this.startingTimeLimit, newStartingTimeLimit -> this.startingTimeLimit = newStartingTimeLimit)
+                    .setTooltip(FXUtils.createTooltip("On PC, this value is multiplied by 1.5, except in ORG levels. The hardcoded maximum is 99.\nHigher values are accepted on PSX, but values above 75 cause visual errors on the HUD."));
         }
 
         // Add start tile / rotation data.
@@ -243,17 +244,17 @@ public class FroggerMapFilePacketGeneral extends FroggerMapFilePacket {
                 newX -> !doesStartTileLookValid() || testStartTileLooksValid(newX, this.startGridCoordZ), newX -> {
             this.startGridCoordX = newX;
             manager.updatePlayerCharacter();
-        });
+        }).setTooltip(FXUtils.createTooltip("The X location on the level grid where the player will start. 0 is the far left.\nSubtract 1 for each multiplayer frog added."));
         editor.addUnsignedShortField("Start zTile", this.startGridCoordZ,
                 newZ -> !doesStartTileLookValid() || testStartTileLooksValid(this.startGridCoordX, newZ), newZ -> {
             this.startGridCoordZ = newZ;
             manager.updatePlayerCharacter();
-        });
+        }).setTooltip(FXUtils.createTooltip("The Z location on the level grid where the player will start. 0 is the far bottom."));
         editor.addEnumSelector("Start Rotation", this.startRotation, FroggerMapStartRotation.values(), false,
                         newStartRotation -> {
             this.startRotation = newStartRotation;
-            manager.updatePlayerCharacter();
-        }).setConverter(new AbstractStringConverter<>(FroggerMapStartRotation::getArrow));
+            manager.updatePlayerCharacter();                                                                                                                   //Commented out until I can figure out how to implement the tooltip alongside it
+        }).setTooltip(FXUtils.createTooltip("Which direction the frog(s) will face when they spawn. This does not affect the starting camera in any way."))    //.setConverter(new AbstractStringConverter<>(FroggerMapStartRotation::getArrow));
 
         // Add frog lighting data.
         if (hasFrogColorData()) {
@@ -261,7 +262,7 @@ public class FroggerMapFilePacketGeneral extends FroggerMapFilePacket {
                 loadFrogLightingFromBgr(ColorUtils.swapRedBlue(newRgb));
                 manager.getFrogLight().setColor(ColorUtils.fromRGB(newRgb, 1F));
                 manager.updatePlayerCharacterLighting();
-            });
+            }).setTooltip(FXUtils.createTooltip("Set an ambient light color for the player frogs. All vanilla levels set this to gray."));
         }
 
         // Add camera data.


### PR DESCRIPTION
Rewrites for a number of existing tooltips and parameter text, primarily in the entity UI. Attempted to clarify some names and unit measurements, add additional notes to certain tooltips or reword them completely, as well as add tooltips to certain object parameters that were lacking them previously.

For parameters that (seemingly) cannot be given tooltips, primarily dropdowns and vector editors, I added text blurbs which are always visible on the UI.