### PR TITLE
Convert spline curve to matrix before updating the display

### DIFF
--- a/src/net/highwayfrogs/editor/games/sony/frogger/map/data/path/segments/FroggerPathSegment.java
+++ b/src/net/highwayfrogs/editor/games/sony/frogger/map/data/path/segments/FroggerPathSegment.java
@@ -256,9 +256,10 @@ public abstract class FroggerPathSegment extends SCGameData<FroggerGameInstance>
             }
 
             onUpdate(pathPreview);
-            frogController.getPathManager().updateEditor();
+            // Apply before updateEditor so the display is correct
             if (onFinish != null)
                 onFinish.run();
+            frogController.getPathManager().updateEditor();
         }, null);
     }
 


### PR DESCRIPTION
When selecting a polygon for a new spline vector (the "Select" button), the curve has to be converted to a matrix before updating the editor display. Otherwise, the previous matrix will be displayed (and XZ Move and Y Move will use the previous values also)